### PR TITLE
fix: use terms in array search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    elasticsearch_query (0.1.5)
+    elasticsearch_query (0.1.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/elasticsearch_query/filter_formatter.rb
+++ b/lib/elasticsearch_query/filter_formatter.rb
@@ -4,12 +4,17 @@ module ElasticsearchQuery
     autoload :Custom,'elasticsearch_query/filter_formatter/custom'
     autoload :Match, 'elasticsearch_query/filter_formatter/match'
     autoload :Range, 'elasticsearch_query/filter_formatter/range'
+    autoload :Terms, 'elasticsearch_query/filter_formatter/terms'
 
     class << self
       def formatter_for( value )
         case value
+        when String && /\.\./
+          FilterFormatter::Range
+        when String && /,/
+          FilterFormatter::Terms
         when String
-          !!value.match( /\.\./ ) ? FilterFormatter::Range : FilterFormatter::Match
+          FilterFormatter::Match
         when Hash
           FilterFormatter::Custom
         end

--- a/lib/elasticsearch_query/filter_formatter.rb
+++ b/lib/elasticsearch_query/filter_formatter.rb
@@ -7,11 +7,14 @@ module ElasticsearchQuery
     autoload :Terms, 'elasticsearch_query/filter_formatter/terms'
 
     class << self
+      ARRAY_REGEX = Regexp.new(',')
+      RANGE_REGEX = Regexp.new('\.\.')
+
       def formatter_for( value )
         case value
-        when String && /\.\./
+        when String && RANGE_REGEX
           FilterFormatter::Range
-        when String && /,/
+        when String && ARRAY_REGEX
           FilterFormatter::Terms
         when String
           FilterFormatter::Match

--- a/lib/elasticsearch_query/filter_formatter/match.rb
+++ b/lib/elasticsearch_query/filter_formatter/match.rb
@@ -2,7 +2,11 @@ module ElasticsearchQuery
   module FilterFormatter
     class Match < Base
       def to_hash
-        { match: { @name => value } }
+        if array?
+          { terms: { @name => value } }
+        else
+          { match: { @name => value } }
+        end
       end
 
       private

--- a/lib/elasticsearch_query/filter_formatter/match.rb
+++ b/lib/elasticsearch_query/filter_formatter/match.rb
@@ -2,25 +2,7 @@ module ElasticsearchQuery
   module FilterFormatter
     class Match < Base
       def to_hash
-        if array?
-          { terms: { @name => value } }
-        else
-          { match: { @name => value } }
-        end
-      end
-
-      private
-
-      def value
-        array? ? array : @value
-      end
-
-      def array?
-        array.length > 1
-      end
-
-      def array
-        @array ||= @value.split(",")
+        { match: { @name => @value } }
       end
     end
   end

--- a/lib/elasticsearch_query/filter_formatter/terms.rb
+++ b/lib/elasticsearch_query/filter_formatter/terms.rb
@@ -1,0 +1,15 @@
+module ElasticsearchQuery
+  module FilterFormatter
+    class Terms < Base
+      def to_hash
+        { terms: { @name => value } }
+      end
+
+      private
+
+      def value
+        @value.split(",")
+      end
+    end
+  end
+end

--- a/lib/elasticsearch_query/version.rb
+++ b/lib/elasticsearch_query/version.rb
@@ -1,3 +1,3 @@
 module ElasticsearchQuery
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/test/elasticsearch_query_test.rb
+++ b/test/elasticsearch_query_test.rb
@@ -27,7 +27,7 @@ class ElasticsearchQueryTest < Minitest::Test
 
   def test_array_filter
     q = ElasticsearchQuery.from_params( { filter: { key: "value1,value2" } } )
-    assert_equal( { query: { match: { key: ["value1", "value2"] } }, size: 20, from: 0 }, q.to_hash )
+    assert_equal( { query: { terms: { key: ["value1", "value2"] } }, size: 20, from: 0 }, q.to_hash )
   end
 
   def test_multiple_match_filters
@@ -65,7 +65,7 @@ class ElasticsearchQueryTest < Minitest::Test
     q = ElasticsearchQuery.from_params( { filter: { key: "value" }, sort: "some_field" } )
     assert_equal( { query: { match: { key: "value" } }, sort: { "some_field" => :asc }, size: 20, from: 0 }, q.to_hash )
   end
-  
+
   def test_asc_sort
     q = ElasticsearchQuery.from_params( { filter: { key: "value" }, sort: "-some_field" } )
     assert_equal( { query: { match: { key: "value" } }, sort: { "some_field" => :desc }, size: 20, from: 0 }, q.to_hash )


### PR DESCRIPTION
We are querying for array objects incorrectly.  To query for arrays, it should be `{ terms: {field: [v1, v2] } }`

Previous resulting query that fails:
`
{
  "query": {
    "bool": {
      "must": [
        {
          "match": {
            "event_name": [
              "export_created",
              "user_updated"
            ]
          }
        },
        {
          "match": {
            "org_guid": "354e1417-54f4-4c29-be50-b9155d6a77aa"
          }
        }
      ]
    }
  }
}
`

New query:
`
{
  "query": {
    "bool": {
      "must": [
        {
          "terms": {
            "event_name": [
              "export_created",
              "user_updated"
            ]
          }
        },
        {
          "match": {
            "org_guid": "354e1417-54f4-4c29-be50-b9155d6a77aa"
          }
        }
      ]
    }
  }
}
`